### PR TITLE
feat: Gracefully print errors for modules

### DIFF
--- a/src/modules/enumerate_files/mod.rs
+++ b/src/modules/enumerate_files/mod.rs
@@ -37,12 +37,11 @@ impl Module for ModuleEnumerateFiles {
         vec![events::Type::DiscoveredDomain(String::new())]
     }
 
-    fn execute(&self, session: &Session, context: Context) {
+    fn execute(&self, session: &Session, context: Context) -> Result<(), String> {
         let domain = match context {
             Context::Domain(domain) => domain,
-            Context::None => {
-                logger::error(self.name(), "Received wrong context, exiting module");
-                return;
+            _ => {
+                return Err("Received wrong context, exiting module".to_string());
             }
         };
         let args = session.get_args();
@@ -95,5 +94,7 @@ impl Module for ModuleEnumerateFiles {
                 }
             }
         }
+
+        Ok(())
     }
 }

--- a/src/modules/enumerate_subdomains/mod.rs
+++ b/src/modules/enumerate_subdomains/mod.rs
@@ -38,12 +38,11 @@ impl Module for ModuleEnumerateSubdomains {
         vec![events::Type::DiscoveredDomain(String::new())]
     }
 
-    fn execute(&self, session: &Session, context: Context) {
+    fn execute(&self, session: &Session, context: Context) -> Result<(), String> {
         let domain = match context {
             Context::Domain(domain) => domain,
-            Context::None => {
-                logger::error(self.name(), "Received wrong context, exiting module");
-                return;
+            _ => {
+                return Err("Received wrong context, exiting module".to_string());
             }
         };
         let args = session.get_args();
@@ -83,5 +82,7 @@ impl Module for ModuleEnumerateSubdomains {
                 session.get_state().discover_subdomain(uri);
             }
         }
+
+        Ok(())
     }
 }

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -24,5 +24,5 @@ pub trait Module: Send + Sync {
     #[allow(dead_code)]
     fn description(&self) -> String;
     fn subscribers(&self) -> Vec<events::Type>;
-    fn execute(&self, session: &Session, context: Context);
+    fn execute(&self, session: &Session, context: Context) -> Result<(), String>;
 }

--- a/src/modules/ready/mod.rs
+++ b/src/modules/ready/mod.rs
@@ -30,10 +30,12 @@ impl Module for ModuleReady {
         vec![events::Type::Ready]
     }
 
-    fn execute(&self, _: &Session, _: Context) {
+    fn execute(&self, _: &Session, _: Context) -> Result<(), String> {
         logger::println(
             "ready",
             "Project Absence is now ready and will start doing its magic!",
-        )
+        );
+
+        Ok(())
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -147,7 +147,9 @@ impl Session {
                         let module_clone = Arc::clone(module);
                         let session_clone = Arc::clone(&self);
                         move || {
-                            module_clone.execute(&session_clone, context);
+                            if let Err(e) = module_clone.execute(&session_clone, context) {
+                                logger::error(module_clone.name(), e)
+                            }
                             session_clone.emit(events::Type::FinishedTask);
                             drop(permit);
                         }


### PR DESCRIPTION
If a module fails, it shouldn't panic but gracefully print errors. Changed the return type of the `execute()` method for the `Module` trait to `Result<(), String>`.